### PR TITLE
Fix stale vfox link

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Version managers for Node.js which read a `.node-version` file include (in alpha
 - [nvm.fish](https://github.com/jorgebucaran/nvm.fish) Node.js version manager lovingly made for Fish. (macOS, Linux)
 - [nvs](https://github.com/jasongin/nvs) Node Version Switcher - A cross-platform tool for switching between versions and forks of Node.js. (macOS, Linux, Windows)
 - [setup-node](https://github.com/actions/setup-node) ([configuration](https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#node-version-file)) Set up your GitHub Actions workflow with a specific version of node.js
-- [vfox](https://vfox.lhan.me) The Multiple SDK Version Manager
+- [vfox](https://vfox.dev) The Multiple SDK Version Manager
 
 Other products which use `.node-version` include:
 


### PR DESCRIPTION
One of the two fox links was stale, and the old link is redirecting to unrelated material.